### PR TITLE
fix(panic): don't skip api key validation and client creation for update subcommands to avoid panics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,8 +144,17 @@ func init() {
 
 		// Skip API key validation for commands that don't need it
 		skipAuthCommands := []string{"login", "config", "init", "completion", "help", "version", "update", "mcp", "auth", "manual"}
+
+		// Only check the first level command name! If we don't do this, we erroneously skip the API key validation for
+		// commands like "assistant update", which actually need it.
+		cmdName := cmd.Name()
+
+		if cmd.Parent() != nil && cmd.Root().Name() != cmd.Parent().Name() {
+			cmdName = cmd.Parent().Name()
+		}
+
 		for _, skipCmd := range skipAuthCommands {
-			if cmd.Name() == skipCmd || (cmd.Parent() != nil && cmd.Parent().Name() == skipCmd) {
+			if cmdName == skipCmd {
 				return nil
 			}
 		}


### PR DESCRIPTION
This PR fixes a panic that is happening whenever you execute a subcommand `update` (e.g.: `assistant update`).

Example:

```
vapi assistant update 123 --json '{}'

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x100ce8838]

goroutine 1 [running]:
github.com/VapiAI/cli/pkg/client.(*VapiClient).DoRawJSON(0x0, {0x101076800, 0x1015fbc80}, {0x100d5ef13, 0x5}, {0x14000206700, 0xf}, {0x140002066e8, 0x2, 0x8})
	/home/runner/work/cli/cli/pkg/client/client.go:84 +0x58
github.com/VapiAI/cli/cmd.init.func26(0x1015c32e0, {0x140001f30b0?, 0x0?, 0x0?})
	/home/runner/work/cli/cli/cmd/assistant.go:282 +0x25c
github.com/VapiAI/cli/cmd.init.TrackCommandWrapper.func86(0x1015c32e0, {0x140001f30b0, 0x1, 0x3})
	/home/runner/work/cli/cli/pkg/analytics/utils.go:14 +0x84
github.com/spf13/cobra.(*Command).execute(0x1015c32e0, {0x140001f3020, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x1015c74e0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/VapiAI/cli/cmd.Execute()
	/home/runner/work/cli/cli/cmd/root.go:193 +0x2c
main.main()
	/home/runner/work/cli/cli/main.go:42 +0x1f0
```