### PR TITLE
fix(auth): preserve state param when opening browser on Windows

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -316,7 +316,11 @@ func generateRandomState() (string, error) {
 func openBrowser(targetURL string) error {
 	switch runtime.GOOS {
 	case "windows":
-		return exec.Command("cmd", "/c", "start", targetURL).Start()
+		// cmd.exe treats & as a command separator, which truncates the URL and
+		// drops query parameters such as `state`. Escape it as ^& so the full
+		// URL reaches the browser. The empty title arg ("") keeps `start` from
+		// mistaking the URL for a window title.
+		return exec.Command("cmd", "/c", "start", "", strings.ReplaceAll(targetURL, "&", "^&")).Start()
 	case "darwin":
 		return exec.Command("open", targetURL).Start()
 	default: // Linux and others


### PR DESCRIPTION
## Problem

On Windows, `vapi login` (and `vapi auth login`) opens the dashboard auth URL **without** the `state` query parameter. macOS and Linux open the correct, complete URL. Because the local callback handler validates `state != expectedState`, the Windows login flow fails even if the user completes the browser step.

## Root cause

`openBrowser` in `pkg/auth/auth.go` launches the URL on Windows via:

```go
exec.Command("cmd", "/c", "start", targetURL)
```

The generated URL contains two query params joined by `&`, e.g.:

```
https://dashboard.vapi.ai/auth/cli?redirect_uri=http%3A%2F%2Flocalhost%3A53234%2Fcallback&state=<token>
```

In `cmd.exe`, `&` is a **command separator**. The command line is split at the `&`, so the browser only receives:

```
start https://dashboard.vapi.ai/auth/cli?redirect_uri=...
```

…and `state=<token>` is parsed as a separate (failing) command. The `state` parameter never reaches the browser. macOS (`open`) and Linux (`xdg-open`) receive the URL as a single argument, so they are unaffected.

## Fix

Escape `&` as `^&` (cmd.exe's caret escape) so the full URL reaches the browser, and pass an empty title argument to `start` so the URL is never mistaken for a window title:

```go
exec.Command("cmd", "/c", "start", "", strings.ReplaceAll(targetURL, "&", "^&"))
```

This is the same approach used by the widely-used `github.com/pkg/browser` library. Only the Windows branch changes; macOS and Linux are untouched.

## Testing

- `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` — both pass
- `go vet ./pkg/auth/...` — clean
- `gofmt` — clean
- `go test -race ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)